### PR TITLE
Patch flink deployment to run on openshift

### DIFF
--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -19,6 +19,10 @@ spec:
           volumeMounts:
             - name: product-inventory-vol
               mountPath: /opt/flink/data
+            - mountPath: /opt/flink/log
+              name: flink-logs
+            - mountPath: /opt/flink/artifacts
+              name: flink-artifacts
       volumes:
         - name: product-inventory-vol
           configMap:
@@ -26,6 +30,10 @@ spec:
             items:
               - key: productInventory.csv
                 path: productInventory.csv
+        - emptyDir: {}
+          name: flink-logs
+        - emptyDir: {}
+          name: flink-artifacts
   jobManager:
     resource:
       memory: "2048m"


### PR DESCRIPTION
This patch allows to run flink example CR on openshift in more restricted env then minikube/kind environemnt.  It fixes the podTemplate to mount emptyDirs to allow write logs and data by flink on local disk.