### PR TITLE
Update Helm command to use empty pod security context

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you choose to do this make sure you update the `data-generator.yaml` file for
 6. Deploy Flink Kubernetes Operator 1.9.0 (the latest stable version):
    ```
    helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.9.0/
-   helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator -n flink
+   helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --set podSecurityContext=null -n flink
    ```
 
 ### Running an example

--- a/recommendation-app/README.md
+++ b/recommendation-app/README.md
@@ -30,7 +30,7 @@ The steps in the [README.md](../README.md) required to be completed for setting 
     ```
     kubectl apply -f recommendation-app/data-generator.yaml -n flink
     ```
-   It continuously produces sample data to `flink.sales.record` and `flink.click.streams`.
+   It continuously produces sample data to `flink.sales.records` and `flink.click.streams`.
 2. Create a ConfigMap that holds product inventory data in CSV format. 
     ```
     kubectl create configmap product-inventory --from-file recommendation-app/productInventory.csv -n flink


### PR DESCRIPTION
The default pod security context in the flink kubernetes operator does not work when deploying on OpenShift. Update the helm install command to pass null podSecurityContext.

Also fixed typo in README