### PR TITLE
Update image pull policy for flink deployment

### DIFF
--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: flink-main-container
           image: quay.io/streamshub/flink-sql-runner:latest
+          imagePullPolicy: Always
           volumeMounts:
             - name: product-inventory-vol
               mountPath: /opt/flink/data


### PR DESCRIPTION
This fix issues when we play on already used kube cluster where old image is cached and we create a new version of sql runner image with for example different path of jar etc...