### PR TITLE
Wait for cert-manager to be ready before installing flink

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you choose to do this make sure you update the `data-generator.yaml` file for
 5. Install cert-manager (this creates cert-manager in a namespace called `cert-manager`):
    ```
    kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+   kubectl wait deployment --all  --for=condition=Available=True --timeout=300s -n cert-manager
    ```
 6. Deploy Flink Kubernetes Operator 1.9.0 (the latest stable version):
    ```


### PR DESCRIPTION
I was seeing webhook issues from the Helm install step if it was run before Cert Manager was actually ready.