### PR TITLE
Fix interactive etl standalone query

### DIFF
--- a/interactive-etl/README.md
+++ b/interactive-etl/README.md
@@ -325,9 +325,20 @@ All from an interactive SQL terminal.
 
 ## Converting to a stand alone Flink job
 
-The ETL query, deployed above, will run like any other Flink streaming job and can be monitored, controlled and scaled through the UI or CLI.
-However, your session cluster might primarily be for data exploration and development, which mean it would be competing for resources with other queries. 
-If your transformed data is needed in production it would be better to deploy the query as a stand-alone Flink Job independent of the session Flink cluster.
+The ETL query (deployed above) will run like any other Flink streaming job and can be monitored, controlled and scaled through the UI or CLI.
+However, your session Flink cluster might primarily be for data exploration and development, which means your ETL job would be competing for resources with other queries. 
+If your transformed data is needed in production, it would be better to deploy the query as a stand-alone Flink Job independent of the session Flink cluster.
 
-There is an example FlinkDeployment CR (`standalone-etl-deployment.yaml`) that would deploy the queries above in Flinks application mode. 
-This will deploy the ETL query in a self-contained flink cluster that can be managed like any other FlinkDeployment.
+There is an example FlinkDeployment CR (`standalone-etl-deployment.yaml`) in this directory that will deploy the queries above in Flink's application mode. 
+This will deploy the ETL query in a self-contained Flink cluster that can be managed like any other FlinkDeployment.
+
+```shell
+kubectl -n flink apply -f standalone-etl-deployment.yaml
+```
+
+Once you know that is running (`kubectl -n flink get pods`), you can see the cleaned data in Kafka by querying the new output topic (this has a different name to the one used in the interactive demo):
+
+```shell
+kubectl exec -it my-cluster-dual-role-0 -n flink -- /bin/bash \
+./bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic flink.cleaned.sales.records
+```

--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -6,22 +6,8 @@ spec:
   image: quay.io/streamshub/flink-sql-runner:latest
   flinkVersion: v1_19
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: "1"
   serviceAccount: flink
-  podTemplate:
-    kind: Pod
-    metadata:
-      name: standalone-etl
-    spec:
-      containers:
-        - name: flink-main-container
-          imagePullPolicy: Always
-          volumeMounts:
-            - mountPath: /opt/flink/log
-              name: flink-logs
-      volumes:
-        - emptyDir: {}
-          name: flink-logs
   jobManager:
     resource:
       memory: "2048m"
@@ -29,9 +15,9 @@ spec:
   taskManager:
     resource:
       memory: "2048m"
-      cpu: 2
+      cpu: 1
   job:
     jarURI: local:///opt/streamshub/flink-sql-runner.jar
-    args: ["CREATE TABLE SalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity STRING, unit_cost STRING, `purchase_time` TIMESTAMP(3) METADATA FROM 'timestamp', WATERMARK FOR purchase_time AS purchase_time - INTERVAL '1' SECOND) WITH 'connector' = 'kafka', 'topic' = 'flink.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.group.id' = 'sales-record-group', 'value.format' = 'avro-confluent', 'value.avro-confluent.url' = 'http://apicurio-registry-service.flink.svc:8080/apis/ccompat/v6', 'scan.startup.mode' = 'latest-offset'); CREATE TABLE CleanedSalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity INT, unit_cost_gbp INT, purchase_time TIMESTAMP(3), PRIMARY KEY (`user_id`) NOT ENFORCED) WITH ('connector' = 'upsert-kafka', 'topic' = 'flink.cleaned.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.client.id' = 'sql-cleaning-client', 'properties.transaction.timeout.ms' = '800000', 'key.format' = 'csv', 'value.format' = 'csv', 'value.fields-include' = 'ALL'); INSERT INTO CleanedSalesRecordTable SELECT invoice_id, user_id, product_id, CAST(quantity AS INT), CAST(TRIM(LEADING '£' from unit_cost) AS INT), purchase_time FROM SalesRecordTable;"]
+    args: ["CREATE TABLE SalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity STRING, unit_cost STRING, `purchase_time` TIMESTAMP(3) METADATA FROM 'timestamp', WATERMARK FOR purchase_time AS purchase_time - INTERVAL '1' SECOND) WITH ('connector' = 'kafka', 'topic' = 'flink.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.group.id' = 'sales-record-group', 'value.format' = 'avro-confluent', 'value.avro-confluent.url' = 'http://apicurio-registry-service.flink.svc:8080/apis/ccompat/v6', 'scan.startup.mode' = 'latest-offset'); CREATE TABLE CleanedSalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity INT, unit_cost_gbp INT, purchase_time TIMESTAMP(3), PRIMARY KEY (`user_id`) NOT ENFORCED) WITH ('connector' = 'upsert-kafka', 'topic' = 'flink.cleaned.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.client.id' = 'sql-cleaning-client', 'properties.transaction.timeout.ms' = '800000', 'key.format' = 'csv', 'value.format' = 'csv', 'value.fields-include' = 'ALL'); INSERT INTO CleanedSalesRecordTable SELECT invoice_id, user_id, product_id, CAST(quantity AS INT), CAST(TRIM(LEADING '£' from unit_cost) AS INT), purchase_time FROM SalesRecordTable;"]
     parallelism: 1
     upgradeMode: stateless


### PR DESCRIPTION
This PR addresses some issues with the Interactive ETL demo. It: 
- Fixes a typo in the Interactive ETL example's standalone query FlinkDeployment.
- Removes the unneeded pod template from the standalone FlinkDeployment.
- Reduces the task manager and cpu request to 1 (to play nicer with local minikube).
- Allows the `kubectl wait` timeout to be customized in the `setup.sh` script. Depending on the resources of your local machine it might take longer for services to become ready.
- Update the README with more detailed instructions for running the standalone FlinkDeployment.