### PR TITLE
Remove image ref in pod template

### DIFF
--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     spec:
       containers:
         - name: flink-main-container
-          image: quay.io/streamshub/flink-sql-runner:latest
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /opt/flink/log

--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
         - name: flink-main-container
-          image: quay.io/streamshub/flink-sql-runner:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 9249


### PR DESCRIPTION
since it is defined in spec.image if flink deployment, it is not needed to be set in pod template.