### PR TITLE
Remove flink log volume from all FlinkDeployments

### DIFF
--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -8,20 +8,6 @@ spec:
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
-  podTemplate:
-    kind: Pod
-    metadata:
-      name: standalone-etl
-    spec:
-      containers:
-        - name: flink-main-container
-          imagePullPolicy: Always
-          volumeMounts:
-            - mountPath: /opt/flink/log
-              name: flink-logs
-      volumes:
-        - emptyDir: {}
-          name: flink-logs
   jobManager:
     resource:
       memory: "2048m"

--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -24,8 +24,6 @@ spec:
           volumeMounts:
             - name: product-inventory-vol
               mountPath: /opt/flink/data
-            - mountPath: /opt/flink/log
-              name: flink-logs
       volumes:
         - name: product-inventory-vol
           configMap:

--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -31,8 +31,6 @@ spec:
             items:
               - key: productInventory.csv
                 path: productInventory.csv
-        - emptyDir: {}
-          name: flink-logs
   jobManager:
     resource:
       memory: "2048m"


### PR DESCRIPTION
Flink already logs to the console which is already ideal for running within a container (it will appear in the container log).

Logging to the filesystem of the container is superfluous (and wasteful of resources).  It also bloats our FlinkDeployments.