### PR TITLE
Make the Interactive ETL standalone example SQL better formatted over…

### DIFF
--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -18,6 +18,51 @@ spec:
       cpu: 1
   job:
     jarURI: local:///opt/streamshub/flink-sql-runner.jar
-    args: ["CREATE TABLE SalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity STRING, unit_cost STRING, `purchase_time` TIMESTAMP(3) METADATA FROM 'timestamp', WATERMARK FOR purchase_time AS purchase_time - INTERVAL '1' SECOND) WITH ('connector' = 'kafka', 'topic' = 'flink.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.group.id' = 'sales-record-group', 'value.format' = 'avro-confluent', 'value.avro-confluent.url' = 'http://apicurio-registry-service.flink.svc:8080/apis/ccompat/v6', 'scan.startup.mode' = 'latest-offset'); CREATE TABLE CleanedSalesRecordTable (invoice_id STRING, user_id STRING, product_id STRING, quantity INT, unit_cost_gbp INT, purchase_time TIMESTAMP(3), PRIMARY KEY (`user_id`) NOT ENFORCED) WITH ('connector' = 'upsert-kafka', 'topic' = 'flink.cleaned.sales.records', 'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 'properties.client.id' = 'sql-cleaning-client', 'properties.transaction.timeout.ms' = '800000', 'key.format' = 'csv', 'value.format' = 'csv', 'value.fields-include' = 'ALL'); INSERT INTO CleanedSalesRecordTable SELECT invoice_id, user_id, product_id, CAST(quantity AS INT), CAST(TRIM(LEADING '£' from unit_cost) AS INT), purchase_time FROM SalesRecordTable;"]
+    args: ["
+        CREATE TABLE SalesRecordTable (
+          invoice_id STRING, 
+          user_id STRING, 
+          product_id STRING, 
+          quantity STRING, 
+          unit_cost STRING, 
+          `purchase_time` TIMESTAMP(3) METADATA FROM 'timestamp', 
+          WATERMARK FOR purchase_time AS purchase_time - INTERVAL '1' SECOND
+        ) WITH (
+          'connector' = 'kafka', 
+          'topic' = 'flink.sales.records', 
+          'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 
+          'properties.group.id' = 'sales-record-group', 
+          'value.format' = 'avro-confluent', 
+          'value.avro-confluent.url' = 'http://apicurio-registry-service.flink.svc:8080/apis/ccompat/v6', 
+          'scan.startup.mode' = 'latest-offset'
+        ); 
+        CREATE TABLE CleanedSalesRecordTable (
+          invoice_id STRING, 
+          user_id STRING, 
+          product_id STRING, 
+          quantity INT, 
+          unit_cost_gbp INT, 
+          purchase_time TIMESTAMP(3), 
+          PRIMARY KEY (`user_id`) NOT ENFORCED
+        ) WITH (
+          'connector' = 'upsert-kafka', 
+          'topic' = 'flink.cleaned.sales.records', 
+          'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9092', 
+          'properties.client.id' = 'sql-cleaning-client', 
+          'properties.transaction.timeout.ms' = '800000', 
+          'key.format' = 'csv', 
+          'value.format' = 'csv', 
+          'value.fields-include' = 'ALL'
+        ); 
+        INSERT INTO CleanedSalesRecordTable 
+          SELECT 
+            invoice_id, 
+            user_id, 
+            product_id, 
+            CAST(quantity AS INT), 
+            CAST(TRIM(LEADING '£' from unit_cost) AS INT), 
+            purchase_time 
+          FROM SalesRecordTable;
+        "]
     parallelism: 1
     upgradeMode: stateless


### PR DESCRIPTION
This PR formats the Standalone ETL FLinkDeployment's SQL over multiple lines so it is easier to read.