### PR TITLE
Use fixed 1.19 sql runner image

### DIFF
--- a/interactive-etl/README.md
+++ b/interactive-etl/README.md
@@ -68,7 +68,7 @@ The interactive SQL client also need access to these plugin libraries, you could
 However, you can run the Flink SQL Runner container locally using the command below (make sure to add the `--net=host` flag so the container can see the forwarded job-manager port):
 
 ```shell
-podman run -it --rm --net=host quay.io/streamshub/flink-sql-runner:latest /opt/flink/bin/sql-client.sh embedded
+podman run -it --rm --net=host quay.io/streamshub/flink-sql-runner:v0.0.1 /opt/flink/bin/sql-client.sh embedded
 ```
 
 If you use docker, you should be able to replace `podman` with `docker` in the command above.

--- a/interactive-etl/flink-session.yaml
+++ b/interactive-etl/flink-session.yaml
@@ -3,7 +3,7 @@ kind: FlinkDeployment
 metadata:
   name: session-cluster
 spec:
-  image: quay.io/streamshub/flink-sql-runner:latest
+  image: quay.io/streamshub/flink-sql-runner:v0.0.1
   flinkVersion: v1_19
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"

--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -3,7 +3,7 @@ kind: FlinkDeployment
 metadata:
   name: standalone-etl
 spec:
-  image: quay.io/streamshub/flink-sql-runner:latest
+  image: quay.io/streamshub/flink-sql-runner:v0.0.1
   flinkVersion: v1_19
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"

--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -3,7 +3,7 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:latest
+  image: quay.io/streamshub/flink-sql-runner:v0.0.1
   flinkVersion: v1_19
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"


### PR DESCRIPTION
This should prevent development builds of the flink-sql docker images harming the flink-sql-examples