### PR TITLE
add instruction to run jobs in other namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ If you choose to do this make sure you update the `data-generator.yaml` file for
 The steps to run each example are described in their own README.
 Make sure you have already [installed Apache Kafka, Apache Flink and Apicurio Registry](#installing-apache-kafka-apache-flink-and-apicurio-registry).
 
+### Running an example in other namespace
+
+By default, we assume all the jobs are running in `flink` namespace, but it is also possible to run jobs in other namespaces.
+Please see [here](flink-role/README.md) for more information.
+
+### Viewing the Apicurio Registry UI
+
 The source topics for the example will contain Avro records.
 You can view the Apicurio Registry UI by running `kubectl port-forward service/apicurio-registry-service 8080 -n flink` and visiting http://localhost:8080/ui in a browser.
 

--- a/flink-role/README.md
+++ b/flink-role/README.md
@@ -1,0 +1,14 @@
+# Run Flink jobs in other namespace
+
+Flink operator by default will watch all namespaces in the kubernetes cluster, but to run Flink jobs in a namespace 
+other than the operator namespace, users are responsible for creating a flink service account in that namespace.
+
+```shell
+kubectl apply -f flink-role/flink-role.yaml -n NAMESPACE
+```
+
+After creating the service account in the NAMESPACE, you can follow each example to deploy FlinkDeployment CR to 
+the NAMESPACE to run the jobs. For example:
+```shell
+kubectl apply -f recommendation-app/flink-deployment.yaml -n NAMESPACE
+```

--- a/flink-role/flink-role.yaml
+++ b/flink-role/flink-role.yaml
@@ -19,12 +19,14 @@ rules:
     resources:
       - pods
       - configmaps
+      - secrets
     verbs:
       - '*'
   - apiGroups:
       - apps
     resources:
       - deployments
+      - deployments/finalizers
     verbs:
       - '*'
 ---

--- a/flink-role/flink-role.yaml
+++ b/flink-role/flink-role.yaml
@@ -1,46 +1,55 @@
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: "v1"
+kind: "ServiceAccount"
 metadata:
   labels:
-    app.kubernetes.io/name: flink-kubernetes-operator
-    app.kubernetes.io/version: 1.10.0
-  name: flink
+    app.kubernetes.io/name: "flink-kubernetes-operator"
+  name: "flink"
+  namespace: "flink"
+
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "RoleBinding"
 metadata:
   labels:
-    app.kubernetes.io/name: flink-kubernetes-operator
-    app.kubernetes.io/version: 1.10.0
-  name: flink
+    app.kubernetes.io/name: "flink-kubernetes-operator"
+  name: "flink"
+  namespace: "flink"
+roleRef:
+  kind: "Role"
+  name: "flink"
+subjects:
+  - kind: "ServiceAccount"
+    name: "flink"
+    namespace: "flink"
+
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "Role"
+metadata:
+  labels:
+    app.kubernetes.io/name: "flink-kubernetes-operator"
+  name: "flink"
+  namespace: "flink"
 rules:
   - apiGroups:
       - ""
     resources:
-      - pods
-      - configmaps
-      - secrets
+      - "pods"
+      - "configmaps"
+      - "pods/finalizers"
     verbs:
-      - '*'
+      - "*"
   - apiGroups:
-      - apps
+      - "apps"
     resources:
-      - deployments
-      - deployments/finalizers
+      - "deployments"
+      - "deployments/finalizers"
     verbs:
-      - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: flink-kubernetes-operator
-    app.kubernetes.io/version: 1.10.0
-  name: flink-role-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: flink
-subjects:
-  - kind: ServiceAccount
-    name: flink
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "list"

--- a/flink-role/flink-role.yaml
+++ b/flink-role/flink-role.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: flink-kubernetes-operator
+    app.kubernetes.io/version: 1.10.0
+  name: flink
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: flink-kubernetes-operator
+    app.kubernetes.io/version: 1.10.0
+  name: flink
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: flink-kubernetes-operator
+    app.kubernetes.io/version: 1.10.0
+  name: flink-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flink
+subjects:
+  - kind: ServiceAccount
+    name: flink


### PR DESCRIPTION
1. Provide example `flink` service account yaml file
2. Provide instruction to run flink jobs on other namespace