### PR TITLE
Push tags to quay

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -57,6 +57,14 @@ jobs:
         with:
           images: |
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
 
       - name: Build and Push Image
         if: github.event_name == 'push'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+    tags: [ '*' ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -39,7 +40,7 @@ jobs:
           registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
           username: "${{ secrets.IMAGE_REPO_USERNAME }}"
           password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
-
+      
       - name: Build Image
         if: github.ref_name != 'main'
         uses: docker/build-push-action@v6
@@ -49,6 +50,14 @@ jobs:
           push: false
           file: data-generator/Dockerfile
 
+      - name: Image metadata
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator
+
       - name: Build and Push Image
         if: github.event_name == 'push' && github.ref_name == 'main'
         uses: docker/build-push-action@v6
@@ -57,4 +66,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: data-generator/Dockerfile
-          tags: ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,7 +34,7 @@ jobs:
         run: mvn -B clean verify
 
       - name: Login to Quay
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
@@ -42,7 +42,7 @@ jobs:
           password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
       
       - name: Build Image
-        if: github.ref_name != 'main'
+        if: github.event_name != 'push'
         uses: docker/build-push-action@v6
         with:
           context: data-generator/
@@ -51,7 +51,7 @@ jobs:
           file: data-generator/Dockerfile
 
       - name: Image metadata
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -59,7 +59,7 @@ jobs:
             ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator
 
       - name: Build and Push Image
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: data-generator/


### PR DESCRIPTION
Preparing to build some release scripts. One idea is to let this workflow react to a tag push and push up a tagged image to quay.

1. it tags main pushes as `main` and `latest` (pick one?)
2. it tags tag pushes with the tag (so git tag v0.0.1 -> image tag v0.0.1)

I imagine a flow like:
1. run a new Release workflow_dispatch action, supplying the target version and new development version
2. the workflow updates the maven versions and any examples/docs to refer to the tag that will exist in future, tests that the docker build works (but does not execute the push), it pushes a commit with the new versions to main and tags that commit with the release version.
3. the workflow updates the maven versions and examples to the new development version (use latest?). pushes that commit to main.
4. Then this integration workflow reacts and creates the tagged image and pushes to quay.