### PR TITLE
Add release script

### DIFF
--- a/.github/scripts/setVersions.sh
+++ b/.github/scripts/setVersions.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# usage: setVersions.sh pomVersion imageVersion [gitTagVersion]
+# if gitTagVersion is provided then a tag will be created after the changes are committed
+
+if [[ $# -lt 2 ]]; then
+    echo "Illegal number of parameters" >&2
+    exit 1
+fi
+if [[ -z "${GITHUB_ACTOR}" ]]; then
+    echo "GITHUB_ACTOR env var not set" >&2
+    exit 1
+fi
+if [[ -z "${GITHUB_ACTOR_ID}" ]]; then
+    echo "GITHUB_ACTOR_ID env var not set" >&2
+    exit 1
+fi
+if [[ -z "${GIT_CONFIG_SCOPE}" ]]; then
+  GIT_CONFIG_SCOPE="--global"
+fi
+
+mvn -B versions:set -DgenerateBackupPoms=false -DnewVersion=${1}
+mvn -B clean verify
+sed --in-place --regexp-extended "s|flink-examples-data-generator:([^[:space:]]*)|flink-examples-data-generator:${2}|g" recommendation-app/data-generator.yaml
+sed --in-place --regexp-extended "s|flink-examples-data-generator:([^[:space:]]*)|flink-examples-data-generator:${2}|g" interactive-etl/data-generator.yaml
+git config ${GIT_CONFIG_SCOPE} user.name "${GITHUB_ACTOR}"
+git config ${GIT_CONFIG_SCOPE} user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+git add .
+git commit -m "Update version to ${1}"
+if [[ -z "${3}" ]]; then
+  echo "no tag supplied, doing nothing"
+else
+  echo "tagging commit as ${3}"
+  git tag -m "${3}" -a "${3}"
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,79 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release Version'
+        required: true
+        default: '0.0.1'
+      snapshotVersion:
+        description: 'Snapshot Version'
+        required: true
+        default: '0.1.0-SNAPSHOT'
+      branch:
+        description: 'Branch to Release'
+        required: false
+        default: 'main'
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Update Sources
+        run: |
+          .github/scripts/setVersions.sh "${{ github.event.inputs.releaseVersion }}" "v${{ github.event.inputs.releaseVersion }}" "v${{ github.event.inputs.releaseVersion }}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test Build Image
+        uses: docker/build-push-action@v6
+        with:
+          context: data-generator/
+          platforms: linux/amd64,linux/arm64
+          push: false
+          file: data-generator/Dockerfile
+      - name: Push Tag
+        run: |
+          git push
+          git push origin "v${{ github.event.inputs.releaseVersion }}"
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator
+          tags: |
+            type=raw,value=v${{ github.event.inputs.releaseVersion }}
+            type=raw,value=latest
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
+          username: "${{ secrets.IMAGE_REPO_USERNAME }}"
+          password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: data-generator/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: data-generator/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Update Sources for Development
+        run: |
+          .github/scripts/setVersions.sh "${{ github.event.inputs.snapshotVersion }}" "latest"
+          git push


### PR DESCRIPTION
Adds a Release Script that:

1. sets the pom.xml versions to the releaseVersion
2. updates the example deployments to refer to the releaseVersion (prefixed with "v")
3. commits to main and tags it as v${releaseVersion}
4. runs maven and docker build to check this builds
5. pushes main and the release tag to github 
6. builds the image and pushes it to quay tagged as `v${releaseVersion}` and `latest`
7. updates the pom.xml versions to the next snapshotVersion
8. updates the example deployments to refer to `latest`
9. pushes to main