### PR TITLE
Use a hard prometheus version

### DIFF
--- a/prometheus-install/prometheus-server.yaml
+++ b/prometheus-install/prometheus-server.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus
+          image: quay.io/prometheus/prometheus:v2.55.1
           ports:
             - containerPort: 9090
           volumeMounts:


### PR DESCRIPTION
To avoid surprising experimenters if the latest prometheus tag eventually becomes incompatible with our configuration