### PR TITLE
Release PR Script

### DIFF
--- a/.github/scripts/setVersions.sh
+++ b/.github/scripts/setVersions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# usage: setVersions.sh pomVersion imageVersion
+
+if [[ $# != 2 ]]; then
+    echo "Illegal number of parameters" >&2
+    exit 1
+fi
+mvn -B versions:set -DgenerateBackupPoms=false -DnewVersion=${1}
+sed --in-place --regexp-extended "s|flink-examples-data-generator:([^[:space:]]*)|flink-examples-data-generator:${2}|g" recommendation-app/data-generator.yaml
+sed --in-place --regexp-extended "s|flink-examples-data-generator:([^[:space:]]*)|flink-examples-data-generator:${2}|g" interactive-etl/data-generator.yaml

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,7 +33,7 @@ jobs:
         run: mvn -B clean verify
 
       - name: Login to Quay
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
@@ -41,20 +41,36 @@ jobs:
           password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
 
       - name: Build Image
-        if: github.ref_name != 'main'
+        if: github.event_name != 'push'
         uses: docker/build-push-action@v6
         with:
           context: data-generator/
           platforms: linux/amd64,linux/arm64
           push: false
           file: data-generator/Dockerfile
+    
+      - name: Image metadata
+        if: github.event_name == 'push'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
 
       - name: Build and Push Image
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: data-generator/
           platforms: linux/amd64,linux/arm64
           push: true
           file: data-generator/Dockerfile
-          tags: ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-examples-data-generator:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: [ "main", "releases/**" ]
+    tags: ["v*"]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "releases/**" ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/release-transition.yaml
+++ b/.github/workflows/release-transition.yaml
@@ -1,0 +1,67 @@
+name: Create Release Transition PR
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to transition'
+        required: false
+        default: 'main'
+      newVersion:
+        description: 'New Version'
+        required: true
+        default: '0.0.1-SNAPSHOT'
+      transition:
+        type: choice
+        description: Choose
+        options:
+        - DEVELOPMENT_TO_RELEASE
+        - RELEASE_TO_DEVELOPMENT
+jobs:
+  create-transition-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Update Sources
+        run: |
+          if [[ "${{ github.event.inputs.transition }}" == "DEVELOPMENT_TO_RELEASE" ]]; then
+            # integration.yaml will push up a matching image tag after Releaser pushes up the v${newVersion} tag
+            IMAGE_TAG="v${{ github.event.inputs.newVersion }}"
+          else
+            # integration.yaml will push images to quay tagged with the branch name on push to branch
+            IMAGE_TAG="${{ github.event.inputs.branch }}"
+          fi
+          .github/scripts/setVersions.sh "${{ github.event.inputs.newVersion }}" $IMAGE_TAG
+      - name: Test maven build
+        run: mvn -B clean verify
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test Build Image
+        uses: docker/build-push-action@v6
+        with:
+          context: data-generator/
+          platforms: linux/amd64,linux/arm64
+          push: false
+          file: data-generator/Dockerfile
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # use token so that the created PR will trigger other actions, default GITHUB_TOKEN does not do this
+          token: ${{ secrets.RELEASE_PAT }}
+          commit-message: "Update to ${{ github.event.inputs.newVersion }}"
+          branch: "release-transition-${{ github.event.inputs.branch }}-${{ github.event.inputs.newVersion }}"
+          signoff: true
+          title: "Release Transition ${{ github.event.inputs.branch }} from ${{ github.event.inputs.transition }}: ${{github.event.inputs.newVersion}}"
+          body: "Release Transition ${{ github.event.inputs.branch }} from ${{ github.event.inputs.transition }}: ${{github.event.inputs.newVersion}}"
+          labels: release

--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ In the `<EXAMPLE_DIRECTORY>/data-generator.yaml` file change the `USE_APICURIO_R
 In the SQL statements supplied in the `args` in the `<EXAMPLE_DIRECTORY>/flink-deployment.yaml`, switch to using CSV:
   - Change `'value.format' = 'avro-confluent'` to `'format' = 'csv'`.
   - Remove `value.avro-confluent.schema-registry.url`.
+
+# Releasing
+
+See [RELEASING.md](RELEASING.md) for instructions on how to release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing
+
+Currently the only external artefact for a release is the data generator image in quay.io
+
+The automation builds and pushes images to quay on push to:
+1. main (image will be tagged as main eg quay.io/streamshub/flink-examples-data-generator:main )
+2. branches named releases/** (image will be tagged as branch name eg quay.io/streamshub/flink-examples-data-generator:releases/0.0)
+3. tag push (image will be tagged with the git tag, for example git tag v0.0.1 -> quay.io/streamshub/flink-examples-data-generator:releases/v0.0.1)
+
+For the branches targeted above we can use github Actions to transition them between two states:
+
+1. Snapshot, where the maven versions are SNAPSHOT and the image references in the deployments use the branch name as image tag.
+2. Release, where the maven version are non-SNAPSHOT and the image references in the deployments point at a tagged image.
+
+## Prerequisites
+You must have permissions to execute manual GitHub Actions workflows and the ability to push tags to this repository
+
+The repository must have a `RELEASE_PAT` secret containing a non-expired GitHub Personal Access Token with write permissions for this repositories contents and PRs.
+
+## To Release a Branch that is in Development
+
+1. Run the [Create Release Transition PR workflow](https://github.com/streams/flink-sql-examples/actions/workflows/release-transition.yaml) setting:
+  - Branch to transition: the branch you want to release (typically main)
+  - New Version: if your development branch is on 0.0.1-SNAPSHOT in the maven projects, you would set this to 0.0.1
+  - Choose: `DEVELOPMENT_TO_RELEASE`
+2. This will create a PR. After CI has run against this PR, review, approve and merge it.
+3. Fetch the branch changes locally and tag the merge commit as `v${version}`. So if you are releasing 0.0.1, run `git tag -a v0.0.1 -m v0.0.1` and push the tag up.
+4. This tag push will trigger [integration.yaml](https://github.com/streams/flink-sql-examples/actions/workflows/integration.yaml) to push a v0.0.1 tagged image to quay.io,
+  matching the references in the deployment YAML that were set in the transition PR.
+5. After the automation pushes the image to quay, you should be able to execute the examples successfully.
+
+## To Transition a Branch back to Development after Release
+
+1. Run the [Create Release Transition PR workflow](https://github.com/streams/flink-sql-examples/actions/workflows/release-transition.yaml) setting:
+  - Branch to transition: the branch you want to release (typically main)
+  - New Version: the next development version, so if you released 0.0.1 this might now be 0.1.0-SNAPSHOT
+  - Choose: `RELEASE_TO_DEVELOPMENT`
+2. This will create a PR. After CI has run against this PR, review, approve and merge it.
+
+## Working with Backports/Bugfixes
+
+If we ever needed to release an older version for some reason (like we wanted to put out a bugfixed 0.0.2 but main has moved far ahead)
+
+1. Branch off the tag you want to work from, the release branch name must start with `releases/`, so if I want to add a bugfix to 0.0.1 I might
+  execute `git checkout -b releases/0.0 v0.0.1 && git push releases/0.0`
+2. Transition the new `releases/0.0` branch to Development following the process above,  setting the branch to `releases/0.0` in the action
+3. Make code changes
+4. Release the branch following the process above, setting the branch to `releases/0.0` in the action

--- a/interactive-etl/data-generator.yaml
+++ b/interactive-etl/data-generator.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: data-generator
-          image: quay.io/streamshub/flink-examples-data-generator:latest
+          image: quay.io/streamshub/flink-examples-data-generator:main
           env:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "my-cluster-kafka-bootstrap.flink.svc:9092"

--- a/recommendation-app/data-generator.yaml
+++ b/recommendation-app/data-generator.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: data-generator
-          image: quay.io/streamshub/flink-examples-data-generator:latest
+          image: quay.io/streamshub/flink-examples-data-generator:main
           env:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "my-cluster-kafka-bootstrap.flink.svc:9092"


### PR DESCRIPTION
Here we go again, I think this is a better flow than one script that does everything in one hit. We use PRs to have a more controlled approach to merging to main, requiring the PR to go through the normal CI.

With this method we can use the existing integration.yaml action to do all the image tagging/building/pushing across branch/tag pushes and PRs.

First, this changes things so the `latest` tag is out of the picture. On push to `main` integration.yaml will produce an image tagged with `main`.

To release the Releaser will:
1. run an action that creates a PR, transitioning the maven version and image tags to the release version.
2. merge PR
3. tag the merge commit and push it up
4. run an action that creates a PR, transitioning the maven version and image tags to the next SNAPSHOT version
5. merge PR
6. delete branches left after PR merge (the repository could be configured to delete them automatically)

The actions can also tolerate working on other branches following a naming convention of `releases/**`. This would enable us to release an older version.

One thing is that we will need to maintain a `RELEASE_PAT `personal access token secret in the repository. This is because the default GITHUB_TOKEN will not trigger on pull_request workflows when it is used to create PRs. In my fork I've been using a fine-grained token with repo/PR permissions just for this one repository.