### PR TITLE
Update to flink-sql runner 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you choose to do this make sure you update the `data-generator.yaml` file for
    ```
 3. Create an Apache Kafka cluster:
    ```
-   kubectl apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n flink 
+   kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n flink 
    ```
 4. Install Apicurio Registry:
    ```
@@ -55,12 +55,12 @@ If you choose to do this make sure you update the `data-generator.yaml` file for
    ```
 5. Install cert-manager (this creates cert-manager in a namespace called `cert-manager`):
    ```
-   kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+   kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
    kubectl wait deployment --all  --for=condition=Available=True --timeout=300s -n cert-manager
    ```
-6. Deploy Flink Kubernetes Operator 1.10.0 (the latest stable version):
+6. Deploy Flink Kubernetes Operator 1.11.0 (the latest stable version):
    ```
-   helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/
+   helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0/
    helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
    --set podSecurityContext=null \
    --set defaultConfiguration."log4j-operator\.properties"=monitorInterval\=30 \

--- a/docs/interactive-etl/index.md
+++ b/docs/interactive-etl/index.md
@@ -72,7 +72,7 @@ The interactive SQL client also need access to these plugin libraries, you could
 However, you can run the Flink SQL Runner container locally using the command below (make sure to add the `--net=host` flag so the container can see the forwarded job-manager port):
 
 ```shell
-podman run -it --rm --net=host quay.io/streamshub/flink-sql-runner:0.1.0 /opt/flink/bin/sql-client.sh embedded
+podman run -it --rm --net=host quay.io/streamshub/flink-sql-runner:0.2.0 /opt/flink/bin/sql-client.sh embedded
 ```
 
 If you use docker, you should be able to replace `podman` with `docker` in the command above.

--- a/interactive-etl/flink-session.yaml
+++ b/interactive-etl/flink-session.yaml
@@ -3,8 +3,8 @@ kind: FlinkDeployment
 metadata:
   name: session-cluster
 spec:
-  image: quay.io/streamshub/flink-sql-runner:0.1.0
-  flinkVersion: v1_19
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink

--- a/interactive-etl/setup.sh
+++ b/interactive-etl/setup.sh
@@ -7,16 +7,17 @@ set -o errexit
 NAMESPACE=${1:-flink}
 KUBE_CMD=${KUBE_CMD:-kubectl}
 TIMEOUT=${TIMEOUT:-180}
-FLINK_OPERATOR_VERSION="1.10.0"
+FLINK_OPERATOR_VERSION="1.11.0"
+CERT_MANAGER_VERSION="1.17.2"
 
-printf "\n\n\e[32mInstalling example components into namespace: %s\e[0m\n\n" ${NAMESPACE}
+printf "\n\n\e[32mInstalling example components into namespace: %s\e[0m\n\n" "${NAMESPACE}"
 
 # Install CertManager - this is needed by the Flink Kubernetes Operator
 printf "\n\e[32mChecking for CertManager install\e[0m\n"
 if ${KUBE_CMD} get namespace cert-manager ; then
     printf "\e[32mCertManager is already installed\e[0m\n"
 else
-    ${KUBE_CMD} create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+    ${KUBE_CMD} create -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 fi
 
 
@@ -56,7 +57,7 @@ else
 fi
 
 printf "\n\e[32mCreating Kafka cluster\e[0m\n"
-${KUBE_CMD} apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n ${NAMESPACE}
+${KUBE_CMD} apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n ${NAMESPACE}
 
 printf "\n\e[32mWaiting for Kafka to be ready...\e[0m\n"
 ${KUBE_CMD} -n ${NAMESPACE} wait --for=condition=Ready --timeout=${TIMEOUT}s kafka my-cluster

--- a/interactive-etl/standalone-etl-deployment.yaml
+++ b/interactive-etl/standalone-etl-deployment.yaml
@@ -3,8 +3,8 @@ kind: FlinkDeployment
 metadata:
   name: standalone-etl
 spec:
-  image: quay.io/streamshub/flink-sql-runner:0.1.0
-  flinkVersion: v1_19
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
   serviceAccount: flink

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Maven plugin versions -->
-        <maven.compiler.version>3.10.1</maven.compiler.version>
+        <maven.compiler.version>3.14.0</maven.compiler.version>
 
         <!-- Dependency versions -->
-        <kafka.version>3.7.0</kafka.version>
-        <apicurio-registry.version>2.6.1.Final</apicurio-registry.version>
-        <avro.version>1.8.1</avro.version>
+        <kafka.version>3.9.1</kafka.version>
+        <apicurio-registry.version>2.6.8.Final</apicurio-registry.version>
+        <avro.version>1.12.0</avro.version>
     </properties>
 
     <modules>

--- a/recommendation-app/flink-deployment.yaml
+++ b/recommendation-app/flink-deployment.yaml
@@ -3,8 +3,8 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:0.1.0
-  flinkVersion: v1_19
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
     metrics.reporters: prom


### PR DESCRIPTION
This PR updates the recommendation app and interactive ETL demos to use the new 0.2.0 release of the SQL runner. It also bumps the kafka client version (of the data generator) to 3.9.1 and bumps other dependencies to their latest versions.

I have run through the tutorials with the new setup and verified that they work as expected.

I will update the HA example tutorial in a separate PR.