### PR TITLE
Update Flink Operator HA tutorial for sql runner 0.2.0

### DIFF
--- a/ha-example/README.md
+++ b/ha-example/README.md
@@ -63,7 +63,8 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:latest
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     # job manager HA settings
     high-availability.type: KUBERNETES
@@ -83,20 +84,27 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:latest
-  flinkConfiguration:
+   image: quay.io/streamshub/flink-sql-runner:0.2.0
+   flinkVersion: v2_0
+   flinkConfiguration:
     # job manager HA settings
     execution.checkpointing.interval: 1min
     state.checkpoints.dir: s3://test/cp
 ```
 The settings above will checkpoint the Task state every 1 minute under the s3 path provided.
 
-## Example: Making the `recommendation-app` fault tolerant and highly available
+## Example: Making the `recommendation-app` fault-tolerant and highly available
 
 Here, we will use the [recommendation-app](../recommendation-app) as an example to demonstrate the job manager HA.
 
-1. Installing Flink Kubernetes Operator with leader election enabled like this:
+
+1. If you haven't already, install cert-manager (this creates cert-manager in a namespace called `cert-manager`):
    ```
+   kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+   kubectl wait deployment --all  --for=condition=Available=True --timeout=300s -n cert-manager
+   ```
+1. Installing Flink Kubernetes Operator with leader election enabled like this:
+   ```shell
    helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
    --set podSecurityContext=null \
    --set defaultConfiguration."log4j-operator\.properties"=monitorInterval\=30 \
@@ -106,38 +114,40 @@ Here, we will use the [recommendation-app](../recommendation-app) as an example 
    kubernetes.operator.leader-election.lease-name:\ flink-operator-lease" \
    -n flink
    ```
-2. Follow the [guide](minio-install/README.md) to deploy and create a local S3 compatible storage service using minio and add a bucket named `test`.
-3. Replace the `MINIO_POD_ID` in `recommendation-app-HA/flink-deployment-ha.yaml` with this command output:
+1. Follow the [guide](minio-install/README.md) to deploy and create a local S3 compatible storage service using minio and add a bucket named `test`.
+1. Deploy the `FlinkDeployment` CR with HA configured
+   ```shell
+   kubectl -n flink apply -f recommendation-app-HA/flink-deployment-ha.yaml
    ```
-   kubectl get pod minio -n flink --template={{.status.podIP}}
+1. There should be 2 recommendation-app job manager and 1 task manager pod deployed
+   ```shell
+   kubectl -n flink get pod -l app=recommendation-app
    ```
-4. Deploy the `FlinkDeployment` CR with HA configured
    ```
-   kubectl apply -f recommendation-app-HA/flink-deployment-ha.yaml -n flink
-   ```
-5. There should be 2 recommendation-app job manager and 1 task manager pod deployed
-   ```
-   kubectl  get pod -l app=recommendation-app -n flink
    NAME                                  READY   STATUS    RESTARTS   AGE
    recommendation-app-76b6854f98-4qcz4   1/1     Running   0          3m59s
    recommendation-app-76b6854f98-9zb24   1/1     Running   0          3m59s
    recommendation-app-taskmanager-1-1    1/1     Running   0          2m5s
    ``` 
-6. Browse the minio console, to make sure the metadata of the job manager is uploaded to `s3://test/ha` 
-7. Find out which job manager pod is the leader
+1. Browse the minio console, to make sure the metadata of the job manager is uploaded to `s3://test/ha` 
+1. Find out which job manager pod is the leader
 
    To do this, check the pod logs.
    If a job manager is the standby, then the log will indicate that it is watching and waiting to becoming the leader.
+   ```shell
+   kubectl -n flink logs recommendation-app-76b6854f98-4qcz4 --tail=2 -f
    ```
-   kubectl  logs -n flink recommendation-app-76b6854f98-4qcz4 --tail=2 -f
+   ```
    2024-12-11 08:31:22,729 INFO  org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMapSharedInformer [] - Starting to watch for flink/recommendation-app-cluster-config-map, watching id:3c7e23f2-fcaa-4f47-8623-fa1ebe9609ea
    2024-12-11 08:31:22,729 INFO  org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMapSharedInformer [] - Starting to watch for flink/recommendation-app-cluster-config-map, watching id:ea191b50-a1ce-43c6-9bfc-a61f739fa8b3
    ```
-8. Delete the leader pod of job manager, and monitor the logs of the standby pod
+1. Delete the leader pod of job manager, and monitor the logs of the standby pod
 
    Keep the step(7) command running, and delete the leader pod in another terminal
+   ```shell
+   kubectl -n flink logs recommendation-app-76b6854f98-4qcz4 --tail=2 -f
    ```
-   kubectl  logs -n flink recommendation-app-76b6854f98-4qcz4 --tail=2 -f
+   ```
    ...
    2024-12-11 08:50:16,438 INFO  org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector [] - New leader elected  for recommendation-app-cluster-config-map.
    2024-12-11 08:50:16,518 INFO  org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector [] - New leader elected 907d6eda-7619-45c5-97c6-e2a6243f56f6 for recommendation-app-cluster-config-map.
@@ -145,13 +155,14 @@ Here, we will use the [recommendation-app](../recommendation-app) as an example 
    2024-12-11 08:50:16,524 INFO  org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl [] - Resource manager service is granted leadership with session id 87a6a102-c77b-4ec2-b263-b20a60921c9e.
    ```
    You should see the leadership is changed to the other pod.
-9. Make sure the checkpointing file is successfully uploaded to `s3://test/cp` via the minio console. 
-10. Monitor the sink topic in kafka
-
+1. Make sure the checkpointing file is successfully uploaded to `s3://test/cp` via the minio console. 
+1. Monitor the sink topic in kafka
    Run the console consumer to get the result of sink topic:
-   ```
-   kubectl exec -it my-cluster-dual-role-0 -n flink -- /bin/bash \
+   ```shell
+   kubectl -n flink exec -it my-cluster-dual-role-0 -- /bin/bash \
    ./bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic flink.recommended.products --from-beginning
+   ```
+   ```
    user-36,"83,172,77,41,128,168","2024-12-11 08:32:35"
    user-63,"15,141,160,64,23,143","2024-12-11 08:32:35"
    user-0,"83,172,77,41,128,168","2024-12-11 08:32:40"
@@ -160,14 +171,18 @@ Here, we will use the [recommendation-app](../recommendation-app) as an example 
    user-75,128,"2024-12-11 09:00:25"
    ```
    It will emit the result by time. Keep this terminal open, we'll check it later.
-11. Delete the task manager pod
+1. Delete the task manager pod
+   ```shell
+   kubectl -n flink delete pod recommendation-app-taskmanager-1-1
    ```
-   kubectl  delete pod/recommendation-app-taskmanager-1-1 -n flink
+   ```
    pod "recommendation-app-taskmanager-1-1" deleted
    ```
-12. Make sure the newly created task manager pod is loading the checkpoint
+1.  Make sure the newly created task manager pod is loading the checkpoint
+    ```shell
+    kubectl -n flink logs recommendation-app-taskmanager-2-1 -f | grep test/cp
     ```
-    kubectl  logs recommendation-app-taskmanager-2-1 -n flink -f | grep test/cp
+    ```
     ...
     2024-12-11 09:02:53,271 INFO  org.apache.flink.runtime.state.heap.HeapRestoreOperation     [] - Starting to restore from state handle: KeyGroupsStateHandle{groupRangeOffsets=KeyGroupRangeOffsets{keyGroupRange=KeyGroupRange{startKeyGroup=0, endKeyGroup=127}}, stateHandle=RelativeFileStateHandle State: s3://test/cp/61f9e79ca6a301ed97cc4c1c6197accf/chk-28/0a34bfc6-188c-405f-8778-114caa6029ec, 0a34bfc6-188c-405f-8778-114caa6029ec [1209621 bytes]}.
     2024-12-11 09:02:54,576 INFO  org.apache.flink.runtime.state.heap.HeapRestoreOperation     [] - Starting to restore from state handle: KeyGroupsStateHandle{groupRangeOffsets=KeyGroupRangeOffsets{keyGroupRange=KeyGroupRange{startKeyGroup=0, endKeyGroup=127}}, stateHandle=RelativeFileStateHandle State: s3://test/cp/61f9e79ca6a301ed97cc4c1c6197accf/chk-28/6b904fdf-d657-4a34-ab72-8f455c1aa578, 6b904fdf-d657-4a34-ab72-8f455c1aa578 [111579 bytes]}.
@@ -177,10 +192,12 @@ Here, we will use the [recommendation-app](../recommendation-app) as an example 
     2024-12-11 09:02:55,572 INFO  org.apache.flink.runtime.state.heap.HeapRestoreOperation     [] - Finished restoring from state handle: KeyGroupsStateHandle{groupRangeOffsets=KeyGroupRangeOffsets{keyGroupRange=KeyGroupRange{startKeyGroup=0, endKeyGroup=127}}, stateHandle=RelativeFileStateHandle State: s3://test/cp/61f9e79ca6a301ed97cc4c1c6197accf/chk-28/ea11d00d-c79b-49d4-b1ff-a73ad01b7197, ea11d00d-c79b-49d4-b1ff-a73ad01b7197 [48167 bytes]}.
     ...
     ```
-13. Check the sink topic consumer output, it should continue from minutes ago, not from the beginning:
-    ```
-    kubectl exec -it my-cluster-dual-role-0 -n flink -- /bin/bash \
+1.  Check the sink topic consumer output, it should continue from minutes ago, not from the beginning:
+    ```shell
+    kubectl -n flink exec -it my-cluster-dual-role-0 -- /bin/bash \
     ./bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic flink.recommended.products --from-beginning
+    ```
+    ``` 
     user-36,"83,172,77,41,128,168","2024-12-11 08:32:35"
     user-63,"15,141,160,64,23,143","2024-12-11 08:32:35"
     ...

--- a/ha-example/minio-install/README.md
+++ b/ha-example/minio-install/README.md
@@ -2,20 +2,30 @@
 
 This folder contains an example minio deployment yaml and the instructions are based on the [minio documentation](https://min.io/docs/minio/kubernetes/upstream/index.html).
 
-1. Deploy the minio with default configurations
+1. Deploy the minio with default configurations:
    ```
-   kubectl apply -f minio.yaml -n flink
+   kubectl -n flink apply -f minio.yaml
    ```
-2. Access the MinIO S3 Console
+1. Expose the minio WebUI:
+   ```shell
+   kubectl -n flink expose deployment minio --name=minio-ui --type=NodePort --port=9090
    ```
-   kubectl port-forward deployment/minio 9000 9090 -n flink
+1. Get the WebUI address. If you are using minikube, you can use the following command to get the address:
+   ```shell
+   minikube service -n flink minio-ui --url 
    ```
-3. Create a bucket via MinIO S3 Console
-
-   Open `http://localhost:9090`, and login with `minioadmin/minioadmin`, then go to `Buckets` -> `Create Bucket` to create a bucket.
-4. Monitor the files in the bucket
-
+   or you can find the assigned nodeport via:
+   ```shell
+   kubectl -n flink get service minio --output='jsonpath="{.spec.ports[0].nodePort}"'
+   ```
+   and add this to any of the K8s cluster's node IPs to get the address.
+1. Create a bucket via MinIO WebUI. To do this, open the address found above and login with username: `minioadmin` and password: `minioadmin`, then go to `Buckets` -> `Create Bucket` to create a bucket called `test`.
+1. Monitor the files in the bucket.
    Click on the `Object Browser` to view the files in the buckets.
+1. Expose the minio API:
+   ```shell
+   kubectl -n flink expose deployment minio --name=minio-api --type=ClusterIP --port=9000
+   ```
 
 After minio is deployed and bucket is created, the flink configuration can be set like this in the `FlinkDeployment` CR:
 ```yaml
@@ -24,20 +34,14 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:v0.0.1
-  flinkVersion: v1_19
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     # minio setting
     s3.access-key: minioadmin
     s3.secret-key: minioadmin
-    s3.endpoint: http://MINIO_POD_ID:9000
+    s3.endpoint: http://minio-api.flink.svc.cluster.local:9000
     s3.path.style.access: "true"
     high-availability.storageDir: s3://test/ha
     state.checkpoints.dir: s3://test/cp
 ```
-Note:
-1. Suppose there is a bucket named `test` in minio.
-2. The `MINIO_POD_ID` can be found via:
-   ```
-   kubectl get pod minio -n flink --template={{.status.podIP}}
-   ```

--- a/ha-example/minio-install/README.md
+++ b/ha-example/minio-install/README.md
@@ -7,15 +7,16 @@ This folder contains an example minio deployment yaml and the instructions are b
    kubectl -n flink apply -f minio.yaml
    ```
    This will create the minio deployment and service for the minio API endpoint (that Flink will use to store state).
-1. Expose the minio WebUI:
+1. We need to create a storage bucket within minio. We could do this by exposing the minio-api service and using the [minio CLI client](https://min.io/docs/minio/linux/reference/minio-mc.html). However, for convenience, we will use the minio web UI. To do this, we need to expose the web UI's port on the minio deployment:
    ```shell
    kubectl -n flink expose deployment minio --name=minio-ui --type=NodePort --port=9090
    ```
+   Depending on how you Kubernetes cluster is set up, you may need to use a different service type (like LoadBalancer) or use an Ingress resource to expose the WebUI. NodePort should be sufficient for local testing with minikube.
 1. Get the WebUI address. If you are using minikube, you can use the following command to get the address:
    ```shell
    minikube service -n flink minio-ui --url 
    ```
-   or you can find the assigned nodeport via:
+   or you can find the assigned NodePort via:
    ```shell
    kubectl -n flink get service minio --output='jsonpath="{.spec.ports[0].nodePort}"'
    ```

--- a/ha-example/minio-install/README.md
+++ b/ha-example/minio-install/README.md
@@ -3,9 +3,10 @@
 This folder contains an example minio deployment yaml and the instructions are based on the [minio documentation](https://min.io/docs/minio/kubernetes/upstream/index.html).
 
 1. Deploy the minio with default configurations:
-   ```
+   ```shell
    kubectl -n flink apply -f minio.yaml
    ```
+   This will create the minio deployment and service for the minio API endpoint (that Flink will use to store state).
 1. Expose the minio WebUI:
    ```shell
    kubectl -n flink expose deployment minio --name=minio-ui --type=NodePort --port=9090
@@ -22,10 +23,6 @@ This folder contains an example minio deployment yaml and the instructions are b
 1. Create a bucket via MinIO WebUI. To do this, open the address found above and login with username: `minioadmin` and password: `minioadmin`, then go to `Buckets` -> `Create Bucket` to create a bucket called `test`.
 1. Monitor the files in the bucket.
    Click on the `Object Browser` to view the files in the buckets.
-1. Expose the minio API:
-   ```shell
-   kubectl -n flink expose deployment minio --name=minio-api --type=ClusterIP --port=9000
-   ```
 
 After minio is deployed and bucket is created, the flink configuration can be set like this in the `FlinkDeployment` CR:
 ```yaml

--- a/ha-example/minio-install/minio.yaml
+++ b/ha-example/minio-install/minio.yaml
@@ -30,3 +30,18 @@ spec:
           hostPath: # MinIO generally recommends using locally-attached volumes
             path: /mnt/disk1/data # Specify a path to a local drive or volume on the Kubernetes worker node
             type: DirectoryOrCreate # The path to the last directory must exist
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: minio
+  name: minio-api
+spec:
+  type: ClusterIP
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000

--- a/ha-example/minio-install/minio.yaml
+++ b/ha-example/minio-install/minio.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: quay.io/minio/minio:latest
+          image: quay.io/minio/minio:RELEASE.2025-05-24T17-08-30Z-cpuv1
           command:
             - /bin/bash
             - -c

--- a/ha-example/recommendation-app-HA/flink-deployment-ha.yaml
+++ b/ha-example/recommendation-app-HA/flink-deployment-ha.yaml
@@ -3,8 +3,8 @@ kind: FlinkDeployment
 metadata:
   name: recommendation-app
 spec:
-  image: quay.io/streamshub/flink-sql-runner:v0.0.1
-  flinkVersion: v1_19
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
     metrics.reporters: prom
@@ -12,7 +12,6 @@ spec:
     # job manager HA settings
     high-availability.type: KUBERNETES
     high-availability.storageDir: s3://test/ha
-    kubernetes.cluster-id: ha-test
     # task checkpointing settings
     execution.checkpointing.interval: 1min
     execution.checkpointing.externalized-checkpoint-retention: RETAIN_ON_CANCELLATION
@@ -23,7 +22,7 @@ spec:
     # S3 (minio) connection settings
     s3.access-key: minioadmin
     s3.secret-key: minioadmin
-    s3.endpoint: http://MINIO_POD_ID:9000
+    s3.endpoint: http://minio-api.flink.svc.cluster.local:9000
     s3.path.style.access: "true"
   serviceAccount: flink
   podTemplate:
@@ -40,9 +39,6 @@ spec:
           volumeMounts:
             - name: product-inventory-vol
               mountPath: /opt/flink/data
-          env:
-            - name: ENABLE_BUILT_IN_PLUGINS
-              value: flink-s3-fs-hadoop-1.19.1.jar;flink-s3-fs-presto-1.19.1.jar
       volumes:
         - name: product-inventory-vol
           configMap:


### PR DESCRIPTION
This PR updates the Flink HA example to run with the new 0.2.0 Flink SQL runner. It also updates the minIO instructions for exposing the S3 compatible-API.

I have verified that this works as per the walk through.