### PR TITLE
Only run CI if relevant files change

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -1,14 +1,28 @@
-name: Build
+name: Docker Build and Push
 
 on:
   push:
     branches: [ "main", "release-**" ]
     tags: [ "[0-9]+.[0-9]+.[0-9]+" ]
+    paths:
+      - 'pom.xml'
+      - '**.java'
+      - 'Dockerfile'
+    paths-ignore:
+      - 'docs/**'
+      - 'deployment-examples/**'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths:
+      - 'pom.xml'
+      - '**.java'
+      - 'Dockerfile'
+    paths-ignore:
+      - 'docs/**'
+      - 'deployment-examples/**'
 
 jobs:
-  build:
+  docker-build-and-push:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I modified the existing workflow to only run if relevant files change.

We can make a new workflow once we need to run CI on something other than the currently relevant files changing.