### PR TITLE
Update flink operator version in data-gen-setup.sh

### DIFF
--- a/tutorials/scripts/data-gen-setup.sh
+++ b/tutorials/scripts/data-gen-setup.sh
@@ -6,7 +6,7 @@ set -e
 NAMESPACE=${1:-flink}
 KUBE_CMD=${KUBE_CMD:-kubectl}
 TIMEOUT=${TIMEOUT:-180}
-FLINK_OPERATOR_VERSION="1.12.0"
+FLINK_OPERATOR_VERSION="1.12.1"
 CERT_MANAGER_VERSION="1.17.2"
 
 printf "\n\n\e[32mInstalling example components into namespace: %s\e[0m\n\n" "${NAMESPACE}"


### PR DESCRIPTION
There is a bug in the 1.12.0 operator so we should be using the more up-to-date 1.12.1 release.

Also the new release seems to have removed the 1.12.0 helm repository and so we need to update the install script to the latest version or it will fail.