### PR TITLE
Update certmanager to 1.18.2

### DIFF
--- a/tutorials/scripts/data-gen-setup.sh
+++ b/tutorials/scripts/data-gen-setup.sh
@@ -7,7 +7,7 @@ NAMESPACE=${1:-flink}
 KUBE_CMD=${KUBE_CMD:-kubectl}
 TIMEOUT=${TIMEOUT:-180}
 FLINK_OPERATOR_VERSION="1.12.1"
-CERT_MANAGER_VERSION="1.17.2"
+CERT_MANAGER_VERSION="1.18.2"
 
 printf "\n\n\e[32mInstalling example components into namespace: %s\e[0m\n\n" "${NAMESPACE}"
 


### PR DESCRIPTION
This PR updated the certmanager version used in the datagen setup script to the latest 1.18.2 version.